### PR TITLE
Explicitly set the provider to virtualbox

### DIFF
--- a/bin/dvm
+++ b/bin/dvm
@@ -126,7 +126,7 @@ case "$1" in
   ssh|ss*)              shift; exec_vagrant ssh $*;;
   status|stat*)         shift; exec_vagrant status $*;;
   suspend|su*|pause|p)  shift; exec_vagrant suspend $*;;
-  up|u*|start|star*)    shift; exec_vagrant up --provision $*;;
+  up|u*|start|star*)    shift; exec_vagrant up --provider virtualbox --provision $*;;
   vagrant|v*)           shift; exec_vagrant $*;;
   *)                    usage; exit 1;;
 esac


### PR DESCRIPTION
dvm breaks when VAGRANT_DEFAULT_PROVIDER is set to vmware_fusion
