### PR TITLE
Fixes inability to stop or delete containers if DOCKER_ARGS used

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,7 +86,7 @@ Vagrant.configure("2") do |config|
     INITD=/usr/local/etc/init.d/docker
     if [ -n '#{args}' ] && grep -q 'docker -d .* $EXPOSE_ALL' $INITD >/dev/null; then
       echo "---> Configuring docker with args '#{args}' and restarting"
-      sudo sed -i -e 's|docker -d .* $EXPOSE_ALL|docker -d #{args}|' $INITD
+      sudo sed -i -e 's|docker -d .* \(-g .*\) $EXPOSE_ALL|docker -d \1 #{args}|' $INITD
       sudo $INITD restart
     fi
     if ! grep -q '8\.8\.8\.8' /etc/resolv.conf >/dev/null; then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,7 +86,7 @@ Vagrant.configure("2") do |config|
     INITD=/usr/local/etc/init.d/docker
     if [ -n '#{args}' ] && grep -q 'docker -d .* $EXPOSE_ALL' $INITD >/dev/null; then
       echo "---> Configuring docker with args '#{args}' and restarting"
-      sudo sed -i -e 's|docker -d .* \(-g .*\) $EXPOSE_ALL|docker -d \1 #{args}|' $INITD
+      sudo sed -i -e 's|docker -d .* \\(-g .*\\)-H.*$EXPOSE_ALL|docker -d \\1 #{args}|' $INITD
       sudo $INITD restart
     fi
     if ! grep -q '8\.8\.8\.8' /etc/resolv.conf >/dev/null; then


### PR DESCRIPTION
## Problem

If you set `DOCKER_ARGS` to anything in `dvm.conf`, you will be unable to stop or delete containers. For an example of what happens, you can look over [this gist](https://gist.github.com/yacn/9195212#file-snipped_no_changes_output-txt).
## Solution

The solution is to modify the `sed` command to save the `-g` parameter passed into Docker in its init file. This parameter is needed because the directory docker expects (`/var/lib/docker`) is a symlink to `/mnt/sda/var/lib/docker`. See [this thread](https://github.com/dotcloud/docker/issues/2714#issuecomment-34408878) for more information.

With the changes in this pull request, this will no longer happen:

```
|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| → mv ~/.dvm/{fixed_,}Vagrantfile

|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| → dvm up
Bringing machine 'dvm' up with 'virtualbox' provider...
[dvm] Importing base box 'boot2docker-0.5.4-1'...
*vagrant SNIP*
[dvm] Running provisioner: shell...
[dvm] Running: inline script
boot2docker: 0.5.4
---> Configuring docker with args '-H unix:// -H tcp://' and restarting

|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| → kitchen list
Instance Driver Provisioner Last Action
default-ubuntu Docker ChefZero <Not Created>

|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| → kitchen create
-----> Starting Kitchen (v1.2.1)
-----> Creating <default-ubuntu>...
Step 0 : FROM ubuntu
Pulling repository ubuntu
*kitchen create SNIP*
Finished creating <default-ubuntu> (3m8.39s).
-----> Kitchen is finished. (3m8.43s)

|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| → kitchen destroy
-----> Starting Kitchen (v1.2.1)
-----> Destroying <default-ubuntu>...
2118a87d5cf2f5d6bc502a3f086b4ab828e6c3023624e2da9e8590eae043ec1f
2118a87d5cf2f5d6bc502a3f086b4ab828e6c3023624e2da9e8590eae043ec1f
Finished destroying <default-ubuntu> (0m0.14s).
-----> Kitchen is finished. (0m0.20s)

|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| → kitchen list
Instance Driver Provisioner Last Action
default-ubuntu Docker ChefZero <Not Created>

|ruby-1.9.3-p448| isaacs-air in ~/git/yacn/dvm/tmp
± |fix/unable-to-stop-delete-containers ✗| →
```

(you can view the full output [here](https://gist.github.com/yacn/9195212#file-raw_fixed_output-txt))

I used [this .kitchen.yml](https://gist.github.com/yacn/9195212#file-kitchen-yml) with [this dvm.conf](https://gist.github.com/yacn/9195212#file-dvm-conf) to confirm.
