### PR TITLE
Allow docker0 CIDR to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ If you wish to change the Docker TCP port or memory settings of the virtual mach
 * `DOCKER_MEMORY`: `512` (in MB)
 * `DOCKER_ARGS`: `-H unix:// -H tcp://`
 
+If you wish to change the network range Docker uses for the `docker0` bridge, set `DOCKER0_CIDR` to the range required.
+
 See [dvm.conf][dvm_conf] for more details.
 
 ## <a name="development"></a> Development

--- a/dvm.conf
+++ b/dvm.conf
@@ -16,6 +16,10 @@
 #
 #export DOCKER_MEMORY="512"
 
+# CIDR range for the docker0 bridge that Docker creates
+#
+#export DOCKER0_CIDR=""
+
 # Arguments passed to start the Docker daemon. Note that `-d' is assumed and
 # not to be included. If set, the value of DOCKER_PORT will not be used unless
 # referenced with `$DOCKER_PORT' in the value. For example:


### PR DESCRIPTION
# NOTE: This pull request depends on #21
## Problem

Using dvm in an environment where the default network range for Docker (`172.16.42.1/24`) conflicts with the local network, containers are unable to reach any hosts on the local network.

Docker allows passing in the `--bip=""` option to set the CIDR range for the `docker0` bridge it creates. However, this alone is not enough. Since Docker will have already been started once, the `docker0` bridge will already exist with the conflicting network range, causing the `--bip` option to take no effect.
## Solution
- To allow setting the CIDR range for the `docker0` bridge, I've added the configuration directive `DOCKER0_CIDR` to `dvm.conf`.
- To fix the issue of `docker0` previously existing, the `bridge-utils` package is installed to provide `brctl` (I did check busybox first to make sure it was not already included), which is then used to remove the `docker0` bridge before starting Docker with the new arguments. 
