### PR TITLE
Update dvm to use boot2docker's $EXTRA_ARGS config option

### DIFF
--- a/dvm.conf
+++ b/dvm.conf
@@ -20,10 +20,14 @@
 #
 #export DOCKER0_CIDR=""
 
-# Arguments passed to start the Docker daemon. Note that `-d' is assumed and
-# not to be included. If set, the value of DOCKER_PORT will not be used unless
-# referenced with `$DOCKER_PORT' in the value. For example:
+# Additional arguments passed to start the Docker daemon. The command used to
+# start the daemon is:
 #
-#     export DOCKER_ARGS="-H unix:// -H tcp://0.0.0.0:$DOCKER_PORT"
+#   /usr/local/bin/docker -d -D -g "$DOCKER_DIR" -H unix:// $DOCKER_HOST $EXTRA_ARGS > /var/lib/boot2docker.log 2>&1 &
 #
-#export DOCKER_ARGS="-H unix:// -H tcp://"
+# If any arguments are specified in DOCKER_ARGS, they will be written to
+# /var/lib/boot2docker/profile like so:
+#
+#   export EXTRA_ARGS=$DOCKER_ARGS
+#
+#export DOCKER_ARGS=""


### PR DESCRIPTION
boot2docker added the `EXTRA_ARGS` config option not too long ago, this pull request updates the `Vagrantfile` to use this instead of `sed`ing the init script for docker. 

Tested with the same `.kitchen.yml` as PR #21 ([link](https://gist.github.com/yacn/9195212#file-kitchen-yml))
