### PR TITLE
Ensure udhcpc is not running for statically defined eth1 interface.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,8 +90,10 @@ module VagrantPlugins
             machine.communicate.tap do |comm|
               networks.each do |n|
                 ifc = "/sbin/ifconfig eth#{n[:interface]}"
+                pid = "/var/run/udhcpc.eth#{n[:interface]}.pid"
                 broadcast = (IPAddr.new(n[:ip]) | (~ IPAddr.new(n[:netmask]))).to_s
                 comm.sudo("#{ifc} down")
+                comm.sudo("if [ -f '#{pid}' ]; then kill `cat #{pid}` && rm -f '#{pid}'; fi")
                 comm.sudo("#{ifc} #{n[:ip]} netmask #{n[:netmask]} broadcast #{broadcast}")
                 comm.sudo("#{ifc} up")
               end


### PR DESCRIPTION
This causes issues where the udhcpc process may eventually attempt to
acquire a new IP address from VitualBox or VMware's DHCP server, and
thus severing the connection to the Docker daemon (from the client's
point of view).

Sadly this is more of a Tiny Core Linux boot issue with the
busybox/udhcpc startup and not in boot2docker so it'll need to be
handled in Vagrant middleware.

Closes #28
Closes #24
Closes #8
