### PR TITLE
Bump to latest 0.9.0 of boot2docker

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,11 +107,11 @@ module VagrantPlugins
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "boot2docker-0.8.0"
+  config.vm.box = "boot2docker-0.9.0"
   config.vm.network "private_network", :ip => ip
 
   config.vm.provider :virtualbox do |v, override|
-    override.vm.box_url = "https://github.com/mitchellh/boot2docker-vagrant-box/releases/download/v0.8.0/boot2docker_virtualbox.box"
+    override.vm.box_url = "https://github.com/mitchellh/boot2docker-vagrant-box/releases/download/v0.9.0/boot2docker_virtualbox.box"
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--memory", Integer(memory)]
@@ -120,7 +120,7 @@ Vagrant.configure("2") do |config|
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
-      override.vm.box_url = "https://github.com/mitchellh/boot2docker-vagrant-box/releases/download/v0.8.0/boot2docker_vmware.box"
+      override.vm.box_url = "https://github.com/mitchellh/boot2docker-vagrant-box/releases/download/v0.9.0/boot2docker_vmware.box"
       v.vmx["memsize"] = Integer(memory)
       v.vmx["numvcpus"] = Integer(cpus)
     end


### PR DESCRIPTION
Issue running brew install docker will get you docker 0.11, and the
current dvm boot2docker installs incompatable version of docker under
the hood.

This is optimistic that @mitchellh will pull/rebuild mitchellh/boot2docker-vagrant-box#47
