### PR TITLE
Add `dvm ip` command to output the address of the Vagrant machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Commands
   destroy         Stops and deletes all traces of the vagrant machine
   env             Outputs environment variables for Docker to connect remotely
   halt, stop      Stops the vagrant machine
+  ip              Outputs the IP address of the vagrant machine
   reload          Restarts vagrant machine, loads new configuration
   resume          Resume the suspended vagrant machine
   ssh             Connects to the machine via SSH

--- a/bin/dvm
+++ b/bin/dvm
@@ -18,6 +18,7 @@ Commands
   destroy         Stops and deletes all traces of the vagrant machine
   env             Outputs environment variables for Docker to connect remotely
   halt, stop      Stops the vagrant machine
+  ip              Outputs the IP address of the vagrant machine
   reload          Restarts vagrant machine, loads new configuration
   resume          Resume the suspended vagrant machine
   ssh             Connects to the machine via SSH
@@ -113,6 +114,11 @@ check() {
   banner 'Ready to go!'
 }
 
+docker_ip() {
+  load_conf
+  echo "${DOCKER_IP:-192.168.42.43}"
+}
+
 setup_env() {
   load_conf
   if [[ $SHELL =~ .*fish$ ]] ; then
@@ -131,6 +137,7 @@ case "$1" in
   destroy|d*)           shift; exec_vagrant destroy "$@";;
   env|e*)               setup_env;;
   halt|h*|stop|sto*)    shift; exec_vagrant halt "$@";;
+  ip|i*)                docker_ip;;
   reload|rel*)          shift; exec_vagrant reload --provision "$@";;
   resume|res*)          shift; exec_vagrant resume "$@";;
   ssh|ss*)              shift; exec_vagrant ssh "$@";;

--- a/bin/dvm
+++ b/bin/dvm
@@ -122,9 +122,9 @@ docker_ip() {
 setup_env() {
   load_conf
   if [[ $SHELL =~ .*fish$ ]] ; then
-    echo "set -x DOCKER_HOST tcp://${DOCKER_IP:-192.168.42.43}:${DOCKER_PORT:-2375}"
+    echo "set -x DOCKER_HOST tcp://$(docker_ip):${DOCKER_PORT:-2375}"
   else
-    echo "export DOCKER_HOST=tcp://${DOCKER_IP:-192.168.42.43}:${DOCKER_PORT:-2375}"
+    echo "export DOCKER_HOST=tcp://$(docker_ip):${DOCKER_PORT:-2375}"
   fi
 }
 


### PR DESCRIPTION
This adds a helper to print the configured (or default) IP address of the Vagrant VM. Similar to [`boot2docker ip`](https://github.com/boot2docker/boot2docker#container-port-redirection), except just reads the configuration and doesn't try to connect to the machine itself.

Example use case would be to connect to published container ports, like:

``` sh
dvm up
docker run -d -p 80:80 my_web_server
curl -i "http://$(dvm ip)/foo"
```
