### PR TITLE
* Upped dvm to use a new 1.4.1 boot2docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ As the core of dvm is a Vagrantfile (surprise!), you can simply download the dvm
 wget -O Vagrantfile http://git.io/dvm-vagrantfile
 ```
 
+## <a name="tls-support"></a> TLS support
+
+By default, the current (1.4.1 as of writing this) boot2docker vagrant image runs docker with TLS enabled. It auto-generates certificates and stores them in /home/docker/.docker inside the VM. The `dvm env` command will copy them to ~/.docker (Or the path you have set for `DOCKER_CERT_PATH` in your `dvm.conf`) on your local machine once the VM has started, and output the correct values for the `DOCKER_CERT_PATH` and `DOCKER_TLS_VERIFY` environment variables.
+
+We strongly recommend against running dvm with an unencrypted Docker socket for security reasons, but if you have tools that cannot be easily switched, you can disable it by changing `DOCKER_TLS` in `$HOME/.dvm/dvm.conf`.
+
 ## <a name="configuration"></a> Configuration
 
 If you wish to change the Docker TCP port or memory settings of the virtual machine, edit `$HOME/.dvm/dvm.conf` for the configuration to be used. By default the following configuration is used:
@@ -218,6 +224,8 @@ If you wish to change the Docker TCP port or memory settings of the virtual mach
 * `DOCKER_MEMORY`: `512` (in MB)
 * `DOCKER_CPUS`: `1`
 * `DOCKER_ARGS`: `-H unix:// -H tcp://`
+* `DOCKER_TLS`: `yes`
+* `DOCKER_CERT_PATH`: `$HOME/.docker`
 
 If you wish to change the network range Docker uses for the `docker0` bridge, set `DOCKER0_CIDR` to the range required.
 

--- a/bin/dvm
+++ b/bin/dvm
@@ -119,12 +119,56 @@ docker_ip() {
   echo "${DOCKER_IP:-192.168.42.43}"
 }
 
+docker_cert_path() {
+  load_conf
+  echo "${DOCKER_CERT_PATH:-$HOME/.docker}"
+}
+
+docker_tls() {
+  load_conf
+  echo "${DOCKER_TLS:-yes}"
+}
+
+copy_certs() {
+  if [ `dvm status | grep -c running` -gt 0 ]; then
+    OPTIONS=$(dvm ssh-config | grep -v '^Host ' | awk -v ORS=' ' 'NF{print "-o " $1 "=" $2}')
+    HOST=$(dvm ssh-config | grep HostName | awk '{print $NF}')
+    if [ ! -d $(docker_cert_path) ]; then
+          mkdir $(docker_cert_path)
+    fi
+    if (ssh ${OPTIONS} $HOST "[ -d /home/docker/.docker ]"); then
+      scp -q ${OPTIONS} $HOST:/home/docker/.docker/*.pem $(docker_cert_path)/
+    fi
+    # If no .pem files exist, assume that TLS is off
+    if [ $(ls $(docker_cert_path)/ | wc -l) -eq 0 ]; then
+        DOCKER_TLS=no
+    fi
+  fi
+}
+
 setup_env() {
   load_conf
+  if [[ $(docker_tls) == 'yes' ]]; then
+      copy_certs
+      DOCKER_PORT=2376
+  fi
   if [[ $SHELL =~ .*fish$ ]] ; then
     echo "set -x DOCKER_HOST tcp://$(docker_ip):${DOCKER_PORT:-2375}"
+    if [[ $(docker_tls) == 'yes' ]]; then
+       echo "set -x DOCKER_TLS_VERIFY=$(docker_tls)"
+       echo "set -x DOCKER_CERT_PATH=$(docker_cert_path)"
+    else
+      echo "set -e DOCKER_TLS_VERIFY"
+    fi
   else
     echo "export DOCKER_HOST=tcp://$(docker_ip):${DOCKER_PORT:-2375}"
+    # if DOCKER_TLS_VERIFY exists docker assumes TLS, so unset to be certain
+    if [[ $(docker_tls) == 'yes' ]]; then
+       echo "export DOCKER_TLS_VERIFY=$(docker_tls)"
+       echo "export DOCKER_CERT_PATH=$(docker_cert_path)"
+    else
+      echo "unset DOCKER_TLS_VERIFY"
+    fi
   fi
 }
 
@@ -140,7 +184,8 @@ case "$1" in
   ip|i*)                docker_ip;;
   reload|rel*)          shift; exec_vagrant reload --provision "$@";;
   resume|res*)          shift; exec_vagrant resume "$@";;
-  ssh|ss*)              shift; exec_vagrant ssh "$@";;
+  ssh)                  shift; exec_vagrant ssh "$@";;
+  ssh-config)           shift; exec_vagrant ssh-config "$@";;
   status|stat*)         shift; exec_vagrant status "$@";;
   suspend|su*|pause|p)  shift; exec_vagrant suspend "$@";;
   up|u*|start|star*)    shift; exec_vagrant up --provision "$@";;

--- a/dvm.conf
+++ b/dvm.conf
@@ -31,3 +31,9 @@
 #   export EXTRA_ARGS=$DOCKER_ARGS
 #
 #export DOCKER_ARGS=""
+
+# If you want the docker deamon to use TLS or not
+#export DOCKER_TLS=no
+
+# Path the TLS certs will live
+#export DOCKER_CERT_PATH=$HOME/.docker


### PR DESCRIPTION
- Added TLS support for dvm for usage with the new 1.4.1 b2d image
- Changed dvm env to copy certs and set correct env vars if TLS is being used
